### PR TITLE
Make sure read/write directories exists before copy

### DIFF
--- a/Platformsh.php
+++ b/Platformsh.php
@@ -124,6 +124,7 @@ class Platformsh
         $this->log("Copying read/write directories back.");
 
         foreach ($this->platformReadWriteDirs as $dir) {
+            $this->execute(sprintf('mkdir -p %s', $dir));
             $this->execute(sprintf('/bin/bash -c "shopt -s dotglob; cp -R ./init/%s/* %s/ || true"', $dir, $dir));
             $this->log(sprintf('Copied directory: %s', $dir));
         }


### PR DESCRIPTION
The read/write directories are file mounts that may not existing in a fresh installation.
We must make sure they exist before copying.
