### PR TITLE
Do `bin/magento module:enable --all` before doing setup:di:compile

### DIFF
--- a/Platformsh.php
+++ b/Platformsh.php
@@ -107,6 +107,10 @@ class Platformsh
      */
     public function compile()
     {
+        $this->log("Enable all modules.");
+
+        $this->execute("php bin/magento module:enable --all");
+
         $this->log("Compiling generated files.");
 
         $this->execute("php bin/magento setup:di:compile-multi-tenant");


### PR DESCRIPTION
We experienced DI errors on our Magento2 setup in Platform.sh. As stated and confirmed by @damz : 

> this is what the latest code in magento/magento-cloud-configuration is doing:
> 
> ```
>     protected function compileDI()
>     {
>         $this->log("Run DI compilation");
>         $this->execute('rm -rf var/generation/*');
>         $this->execute('rm -rf var/di/*');
>         $this->execute("cd bin/; /usr/bin/php ./magento module:enable --all");
>         $this->execute("cd bin/; /usr/bin/php ./magento setup:di:compile");
>     }
> ```
> 
> The code in platformsh/magento2-configuration, which is an earlier iteration of the same, does this instead:
> 
> ```
>     public function compile()
>     {
>         $this->log("Compiling generated files.");
>         $this->execute("php bin/magento setup:di:compile-multi-tenant");
>     }
> ```
> 
> Indeed, if on the environment I launch `php bin/magento setup:di:compile-multi-tenant` manually it does get the right modules
