### PR TITLE
Alter Compile function to work with M2 >=2.1

### DIFF
--- a/Platformsh.php
+++ b/Platformsh.php
@@ -116,6 +116,7 @@ class Platformsh
         //this changed at 2.1.0 so we'll try for below 2.1 and then catch when this fails to use the more modern method
         try {
 
+            #the runtime exception is throw from line 431 of execute
             $this->execute("php bin/magento setup:di:compile-multi-tenant");
 
         } catch (\RuntimeException $e)

--- a/Platformsh.php
+++ b/Platformsh.php
@@ -118,7 +118,7 @@ class Platformsh
 
             $this->execute("php bin/magento setup:di:compile-multi-tenant");
 
-        } catch (Exception $e)
+        } catch (\RuntimeException $e)
         {
             $this->execute("php bin/magento setup:di:compile");
         }

--- a/Platformsh.php
+++ b/Platformsh.php
@@ -113,7 +113,15 @@ class Platformsh
 
         $this->log("Compiling generated files.");
 
-        $this->execute("php bin/magento setup:di:compile-multi-tenant");
+        //this changed at 2.1.0 so we'll try for below 2.1 and then catch when this fails to use the more modern method
+        try {
+
+            $this->execute("php bin/magento setup:di:compile-multi-tenant");
+
+        } catch (Exception $e)
+        {
+            $this->execute("php bin/magento setup:di:compile");
+        }
     }
 
     /**


### PR DESCRIPTION
The release of Magento 2.1.0 removed setup:di:compile-multi-tenant. As we haven't initiated Magento in this script we can't check its version number. To get round this I've put in some error handling. First we try multi-tenant complilation and if that fails we catch as we are greater or equal to 2.1 and use setup:di:compile.
